### PR TITLE
Fix url and server command in welcome message

### DIFF
--- a/lib/utopia/command/site.rb
+++ b/lib/utopia/command/site.rb
@@ -110,10 +110,10 @@ module Utopia
 					puts "make your life easier and more enjoyable.".center(78)
 					puts ""
 					puts "To start the development server, run:".center(78)
-					puts "rake server".center(78)
+					puts "bake utopia:development".center(78)
 					puts ""
 					puts "For extreme productivity, please consult the online documentation".center(78)
-					puts "https://github.com/ioquatix/utopia".center(78)
+					puts "https://github.com/socketry/utopia".center(78)
 					puts " ~ Samuel.  ".rjust(78)
 				end
 			end


### PR DESCRIPTION
The welcome message after running `utopia site create` is slightly out of date:
* Uses old `rake server` command
* Has old repository URL.

## Types of Changes

<!-- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Performance improvement.
- [x] Documentation

## Testing

<!-- Put an `x` in all the boxes that apply: -->
- [ ] I added new tests for my changes.
- [ ] I ran all the tests locally.
