### PR TITLE
Fix old commands in documentation

### DIFF
--- a/guides/integrating-with-javascript/README.md
+++ b/guides/integrating-with-javascript/README.md
@@ -21,13 +21,13 @@ $ yarn init
 Then install jquery using `yarn`:
 
 ```bash
-$ yarn install jquery
+$ yarn add jquery
 ```
 
 Copy the distribution scripts to `public/_components`:
 
 ```bash
-$ bundle exec bake utopia:yarn:update
+$ bundle exec bake utopia:node:update
 ```
 
 Then add the appropriate `<script>` tags to `pages/_page.xnode`:

--- a/guides/server-setup/README.md
+++ b/guides/server-setup/README.md
@@ -33,7 +33,7 @@ ENV["DATABASE_VARIANT"] will default to "staging1" unless otherwise specified.
 
 To set a value, write `KEY=VALUE`. To unset a key, write `KEY`.
 
-When you run `rake` tasks or spawn a server, the values in `config/environment.yaml` will be the defaults. You can override them by manually specifying them, e.g. `DATABASE_ENV=development rake db:info`.
+When you run `bake` tasks or spawn a server, the values in `config/environment.yaml` will be the defaults. You can override them by manually specifying them, e.g. `DATABASE_ENV=development bake db:info`.
 
 ## Platform
 

--- a/setup/site/README.md
+++ b/setup/site/README.md
@@ -6,11 +6,11 @@ Welcome to Utopia, a Ruby framework for web site and application development. Fo
 
 To start the development server, simply execute
 
-	> rake
+	> bake
 	Generating transient session key for development...
 	20:57:36 - INFO - Starting Falcon HTTP server on localhost:9292
 	20:57:36 - INFO - Guard::RSpec is running
 	20:57:36 - INFO - Guard is now watching at '...'
 	[1] guard(main)>
 
-Then browse http://localhost:9292 (or as specified) to see your new site.
+Then browse https://localhost:9292 (or as specified) to see your new site.


### PR DESCRIPTION
Fixes some old references to `rake` and `yarn` commands which have now changed.

## Types of Changes

<!-- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Performance improvement.
- [x] Documentation.

## Testing

<!-- Put an `x` in all the boxes that apply: -->
- [ ] I added new tests for my changes.
- [ ] I ran all the tests locally.
