### PR TITLE
Remove duplicate Utopia::Static middlware from sample config.

### DIFF
--- a/setup/site/config.ru
+++ b/setup/site/config.ru
@@ -14,6 +14,7 @@ else
 	use Rack::ShowExceptions unless UTOPIA.testing?
 end
 
+# serve static files from public/
 use Utopia::Static, root: 'public'
 
 use Utopia::Redirection::Rewrite, {
@@ -39,6 +40,7 @@ use Utopia::Session,
 
 use Utopia::Controller
 
+# serve static files from pages/
 use Utopia::Static
 
 # Serve dynamic content


### PR DESCRIPTION
The sample `config.ru` file has two `Utopia::Static` middlewares installed, each configured slightly differently!?

## Types of Changes

<!-- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Performance improvement.
- [x] Documentation

## Testing

<!-- Put an `x` in all the boxes that apply: -->
- [ ] I added new tests for my changes.
- [ ] I ran all the tests locally.
