### PR TITLE
Fix warning about shadowed variable.

### DIFF
--- a/lib/utopia/content/link.rb
+++ b/lib/utopia/content/link.rb
@@ -96,17 +96,17 @@ module Utopia
 			def to_anchor(base: nil, content: self.title, builder: nil, **attributes)
 				attributes[:class] ||= 'link'
 				
-				Trenni::Builder.fragment(builder) do |builder|
+				Trenni::Builder.fragment(builder) do |inner_builder|
 					if href?
 						attributes[:href] ||= relative_href(base)
 						attributes[:target] ||= @info[:target]
 						
-						builder.inline('a', attributes) do
-							builder.text(content)
+						inner_builder.inline('a', attributes) do
+							inner_builder.text(content)
 						end
 					else
-						builder.inline('span', attributes) do
-							builder.text(content)
+						inner_builder.inline('span', attributes) do
+							inner_builder.text(content)
 						end
 					end
 				end


### PR DESCRIPTION
Fixes a warning about showed variable:
```
/Users/michael/.rvm/gems/ruby-2.5.1/gems/utopia-2.18.3/lib/utopia/content/link.rb:99: warning: shadowing outer local variable - builder
```

## Types of Changes

<!-- Put an `x` in all the boxes that apply: -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Performance improvement.

## Testing

<!-- Put an `x` in all the boxes that apply: -->
- [ ] I added new tests for my changes.
- [x] I ran all the tests locally.
