### PR TITLE
Install gems "globally".

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -53,5 +53,4 @@ jobs:
       run: |
         git config --global user.email "samuel@oriontransfer.net"
         git config --global user.name "Samuel Williams"
-        bundle install
         ${{matrix.env}} bundle exec rspec

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -53,4 +53,5 @@ jobs:
       run: |
         git config --global user.email "samuel@oriontransfer.net"
         git config --global user.name "Samuel Williams"
+        bundle install
         ${{matrix.env}} bundle exec rspec

--- a/spec/utopia/command_spec.rb
+++ b/spec/utopia/command_spec.rb
@@ -42,6 +42,9 @@ RSpec.describe "utopia command" do
 			# If we don't delete this, when running on travis, it will try submit the coverage report.
 			ENV.delete('COVERAGE')
 			
+			# In order to make this work in a vendored test environment, we need to seed the "local" environment with the "utopia" gem and all it's dependencies. Otherwise, the commands will fail because they can't find the dependencies (they are vendored in the source root but not in `dir`):
+			system("bundle", "install", "--system")
+			
 			example.run
 		end
 	end


### PR DESCRIPTION
## Description

It seems like bundler is failing on sub-commands because the gems may not be installed in an accessible location, i.e. maybe they are being installed to `vendor/bundle`.

### Types of Changes

- Maintenance.
