### PR TITLE
Don't sign the gem during test build.

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -7,6 +7,7 @@ permissions:
 
 env:
   CONSOLE_OUTPUT: XTerm
+  BUNDLE_WITH: maintenance
 
 jobs:
   test:

--- a/gems.rb
+++ b/gems.rb
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :maintenance, optional: true do
-	gem "bake-gem"
+	gem "bake-gem", "~> 0.3"
 	gem "bake-modernize"
 	
 	gem "utopia-project"

--- a/spec/utopia/command_spec.rb
+++ b/spec/utopia/command_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "utopia command" do
 	
 	before(:all) do
 		# We need to build a package to test deployment:
-		system("bundle", "exec", "bake", "gem:build") or abort("Could not build package for setup spec!")
+		system("bundle", "exec", "bake", "gem:build", "--signing-key", "no") or abort("Could not build package for setup spec!")
 	end
 	
 	around(:each) do |example|

--- a/utopia.gemspec
+++ b/utopia.gemspec
@@ -10,8 +10,8 @@ Gem::Specification.new do |spec|
 	spec.authors = ["Samuel Williams", "Huba Nagy", "Michael Adams", "Olle Jonsson", "System Administrator", "k1tsu"]
 	spec.license = "MIT"
 	
-	spec.cert_chain  = ['release.cert']
-	spec.signing_key = File.expand_path('~/.gem/release.pem')
+	# spec.cert_chain  = ['release.cert']
+	# spec.signing_key = File.expand_path('~/.gem/release.pem')
 	
 	spec.homepage = "https://github.com/ioquatix/utopia"
 	


### PR DESCRIPTION
Signed gemspec causes the test's internal gem build to fail because it doesn't have the signing key. Disable it for now until we find a better solution.

### Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
