### PR TITLE
Add support for relative base uri.

### DIFF
--- a/lib/utopia/content/document.rb
+++ b/lib/utopia/content/document.rb
@@ -38,6 +38,27 @@ module Utopia
 				super()
 			end
 			
+			# @returns [Path] The original request path, if known.
+			def request_path
+				Path[request.env["REQUEST_PATH"]]
+			end
+			
+			protected def current_base_uri_path
+				self.current.node.uri_path
+			end
+			
+			# Compute the relative path from the curent base uri (e.g. the node being rendered) to the request uri. This path can be used to ensure resources are loaded relative to a given path.
+			#
+			# | Relative To   | Request Path           | Base URI     |
+			# |---------------|------------------------|--------------|
+			# | "/page"       | "/index"               | ""           |
+			# | "/blog/entry" | "/blog/2025/05/my-cat" | "../.."      |
+			#
+			# @returns [String] the base uri for the current page.
+			def base_uri(relative_to = self.current_base_uri_path)
+				Path[relative_to].dirname.shortest_path(request_path)
+			end
+			
 			def [] key
 				@attributes[key]
 			end

--- a/setup/site/pages/_page.xnode
+++ b/setup/site/pages/_page.xnode
@@ -9,7 +9,7 @@
 			<title>Utopia</title>
 		<?r end ?>
 		
-		<base href="#{first.node.uri_path}"/>
+		<base href="#{document.base_uri}"/>
 		<meta name="viewport" content="width=device-width, initial-scale=1"/>
 		
 		<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous" />


### PR DESCRIPTION
Deploying static sites on GitHub pages sometimes changes the root URI, e.g. `https://my-organization.github.io/my-project/`. Absolute base URIs are therefore problematic.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
