### PR TITLE
Fix broken links in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,23 +13,23 @@ Utopia is a website generation framework which provides a robust set of tools to
 
 ## Usage
 
-Please see the [project documentation](https://github.com/ioquatix/utopia) for more details.
+Please see the [project documentation](https://socketry.github.io/utopia/) for more details.
 
-  - [Getting Started](https://github.com/ioquatix/utopiaguides/getting-started/index) - This guide explains how to set up a `utopia` website for local development and deployment.
+  - [Getting Started](https://socketry.github.io/utopia/guides/getting-started/index.html) - This guide explains how to set up a `utopia` website for local development and deployment.
 
-  - [Middleware](https://github.com/ioquatix/utopiaguides/middleware/index) - This guide gives an overview of the different Rack middleware used by Utopia.
+  - [Middleware](https://socketry.github.io/utopia/guides/middleware/index.html) - This guide gives an overview of the different Rack middleware used by Utopia.
 
-  - [Server Setup](https://github.com/ioquatix/utopiaguides/server-setup/index) - This guide explains how to deploy a `utopia` web application.
+  - [Server Setup](https://socketry.github.io/utopia/guides/server-setup/index.html) - This guide explains how to deploy a `utopia` web application.
 
-  - [Installing JavaScript Libraries](https://github.com/ioquatix/utopiaguides/integrating-with-javascript/index) - Utopia integrates with Yarn and provides a [bake task](https://github.com/ioquatix/bake) to simplify deployment packages distributed using `yarn` that implement the `dist` sub-directory convention.
+  - [Installing JavaScript Libraries](https://socketry.github.io/utopia/guides/integrating-with-javascript/index.html) - Utopia integrates with Yarn and provides a [bake task](https://github.com/ioquatix/bake) to simplify deployment packages distributed using `yarn` that implement the `dist` sub-directory convention.
 
-  - [What is XNode?](https://github.com/ioquatix/utopiaguides/what-is-xnode/index) - This guide explains the `xnode` view layer and how it can be used to build efficient websites.
+  - [What is XNode?](https://socketry.github.io/utopia/guides/what-is-xnode/index.html) - This guide explains the `xnode` view layer and how it can be used to build efficient websites.
 
-  - [Updating Utopia](https://github.com/ioquatix/utopiaguides/updating-utopia/index) - This guide explains how to update existing `utopia` websites.
+  - [Updating Utopia](https://socketry.github.io/utopia/guides/updating-utopia/index.html) - This guide explains how to update existing `utopia` websites.
 
 ## Releases
 
-Please see the [project releases](https://github.com/ioquatix/utopiareleases/index) for all releases.
+Please see the [project releases](https://socketry.github.io/utopia/releases/index.html) for all releases.
 
 ### v2.27.0
 


### PR DESCRIPTION
I updated the broken Usage and Releases section links in readme to point to [Utopia's documentation](https://socketry.github.io/utopia/index.html). (If you'd prefer to link to the local .md files in `/guides/` let me know and I'll use those instead).

Fixes https://github.com/socketry/utopia/issues/43.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Documentation.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
