### PR TITLE
Replace rspec with sus in Getting Started guide

### DIFF
--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -57,17 +57,14 @@ errors:
 
 ## Testing
 
-Utopia websites include a default set of tests using `rspec`. These specs can test against the actual running website. 
+Utopia websites include a default set of tests using `sus`. These specs can test against the actual running website.
 
 ~~~ bash
-$ rspec
+$ sus
 
-website
-1 samples: 1x 200. 1170.96 requests per second. S/D: 0.000µs.
-  should be responsive
-
-Finished in 0.61764 seconds (files took 0.64705 seconds to load)
-1 example, 0 failures
+1 samples: 1x 200. 3703.7 requests per second. S/D: 0.000µs.
+1 passed out of 1 total (2 assertions)
+🏁 Finished in 247.4ms; 8.085 assertions per second.
 ~~~
 
 The website test will spider all pages on your site and report any broken links as failures.


### PR DESCRIPTION
The test that comes with `utopia:site:create` now uses `sus` instead of `rspec`. Updated the Getting Started guide to match.

The complete output of `sus` on a fresh site was actually

```
1 samples: 1x 200. 3703.7 requests per second. S/D: 0.000µs.
1 passed out of 1 total (2 assertions)
🏁 Finished in 247.4ms; 8.085 assertions per second.
😭 You should write more tests and assertions!
🐢 Slow tests:
        247.3ms: describe website it should be responsive test/website.rb:16
```

but I thought the first three lines got the point across - happy to include the rest of the message if you'd prefer. Thanks!

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Documentation.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
