### PR TITLE
Add explicit irb dependency

### DIFF
--- a/utopia.gemspec
+++ b/utopia.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
 	spec.add_dependency "concurrent-ruby", "~> 1.2"
 	spec.add_dependency "console", "~> 1.24"
 	spec.add_dependency "http-accept", "~> 2.1"
+	spec.add_dependency "irb"
 	spec.add_dependency "mail", "~> 2.6"
 	spec.add_dependency "mime-types", "~> 3.0"
 	spec.add_dependency "msgpack"


### PR DESCRIPTION
Under Ruby 3.4, `bake utopia:shell` logs the warning:

```
/<snip>/utopia-2.30.0/lib/utopia/shell.rb:8: warning: irb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add irb to your Gemfile or gemspec to silence this warning.
```

Adding an explicit dependency on the `irb` gem to the gemspec silences this warning.

## Types of Changes

- Maintenance.

## Contribution

- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
