### PR TITLE
Watch gems.locked with Guard

### DIFF
--- a/setup/site/Guardfile
+++ b/setup/site/Guardfile
@@ -3,6 +3,7 @@
 group :development do
 	guard :falcon, port: 9292 do
 		watch("Gemfile.lock")
+		watch("gems.locked")
 		watch("config.ru")
 		watch(%r{^config|lib|pages/.*})
 		


### PR DESCRIPTION
Guard currently watches `Gemfile.lock`, but the site generated by `utopia:site:create` uses `gems.locked` instead. Add `gems.locked` to `Guardfile` so the development server reloads as expected when the bundle changes.

<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
Link to any relevant issues.
-->

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
