### PR TITLE
post-receive: git submodule update uses "--init" option

### DIFF
--- a/setup/server/git/hooks/post-receive
+++ b/setup/server/git/hooks/post-receive
@@ -61,7 +61,7 @@ end
 puts "Deploying to #{GIT_WORK_TREE} as #{DEPLOY_USER}:#{DEPLOY_GROUP}..."
 Dir.chdir(GIT_WORK_TREE) do
 	sudo %W{git checkout -f}
-	sudo %W{git submodule update -i}
+	sudo %W{git submodule update --init}
 	
 	if File.exist? "gems.rb"
 		sudo %W{bundle install}


### PR DESCRIPTION
This PR fixes a detail in git usage, which gave an error in the PR #49.

## Types of Changes

- Bug fix.

## Contribution

- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
