### PR TITLE
Use Sus temporary directory fixture

### DIFF
--- a/test/utopia/command.rb
+++ b/test/utopia/command.rb
@@ -4,12 +4,14 @@
 # Copyright, 2018-2025, by Samuel Williams.
 
 require "fileutils"
-require "tmpdir"
 require "yaml"
 
 require "bundler"
+require "sus/fixtures/temporary_directory_context"
 
 describe "utopia command" do
+	include Sus::Fixtures::TemporaryDirectoryContext
+	
 	let(:utopia_path) {File.expand_path("../..", __dir__)}
 	
 	def around
@@ -40,90 +42,81 @@ describe "utopia command" do
 	end
 	
 	it "should generate sample site" do
-		Dir.mktmpdir("test-site") do |dir|
-			install_packages(dir)
-			
-			system("bundle", "exec", "bake", "utopia:site:create", chdir: dir, exception: true)
-			
-			expected_files = [".git", "gems.rb", "gems.locked", "readme.md", "bake.rb", "config.ru", "lib", "pages", "public", "test"]
-			site_files = Dir.entries(dir)
-			
-			expected_files.each do |file|
-				expect(site_files).to be(:include?, file)
-			end
-			
-			expect(
-				system("bundle", "exec", "bake", "test", chdir: dir)
-			).to be == true
+		install_packages(root)
+		
+		system("bundle", "exec", "bake", "utopia:site:create", chdir: root, exception: true)
+		
+		expected_files = [".git", "gems.rb", "gems.locked", "readme.md", "bake.rb", "config.ru", "lib", "pages", "public", "test"]
+		site_files = Dir.entries(root)
+		
+		expected_files.each do |file|
+			expect(site_files).to be(:include?, file)
 		end
+		
+		expect(
+			system("bundle", "exec", "bake", "test", chdir: root)
+		).to be == true
 	end
 	
 	it "should generate a sample server" do
-		Dir.mktmpdir("test-server") do |dir|
-			install_packages(dir)
-			
-			system("bundle", "exec", "bake", "utopia:server:create", chdir: dir, exception: true)
-			expect(Dir.entries(dir)).to be(:include?, ".git")
-			
-			system("git", "config", "--local", "core.sharedRepository", "false", chdir: dir, exception: true)
-			system("chmod", "-Rf", "g-x", ".git", chdir: dir, exception: true)
-			system("rm", "-f", ".git/hooks/post-receive", chdir: dir, exception: true)
-			
-			environment = YAML.load_file(File.join(dir, "config/environment.yaml"))
-			expect(environment).to be(:include?, "VARIANT")
-			expect(environment).to be(:include?, "UTOPIA_SESSION_SECRET")
-		end
+		install_packages(root)
+		
+		system("bundle", "exec", "bake", "utopia:server:create", chdir: root, exception: true)
+		expect(Dir.entries(root)).to be(:include?, ".git")
+		
+		system("git", "config", "--local", "core.sharedRepository", "false", chdir: root, exception: true)
+		system("chmod", "-Rf", "g-x", ".git", chdir: root, exception: true)
+		system("rm", "-f", ".git/hooks/post-receive", chdir: root, exception: true)
+		
+		environment = YAML.load_file(File.join(root, "config/environment.yaml"))
+		expect(environment).to be(:include?, "VARIANT")
+		expect(environment).to be(:include?, "UTOPIA_SESSION_SECRET")
 	end
 	
 	it "should not trash the sample server during update" do
-		Dir.mktmpdir("test-server") do |dir|
-			install_packages(dir)
-			
-			system("bundle", "exec", "bake", "utopia:server:create", chdir: dir, exception: true)
-			system("git", "config", "--local", "core.sharedRepository", "false", chdir: dir, exception: true)
-			system("chmod", "-Rf", "g-x", ".git", chdir: dir, exception: true)
-			system("rm", "-f", ".git/hooks/post-receive", chdir: dir, exception: true)
-			
-			# Run the server update command:
-			system("bundle", "exec", "bake", "utopia:server:update", chdir: dir, exception: true)
-			
-			# Check a couple of files to make sure they have group read and write access after the update:
-			Dir.glob(File.join(dir, ".git/**/*")).each do |path|
-				expect(group_rw(path)).to be == true
-			end
+		install_packages(root)
+		
+		system("bundle", "exec", "bake", "utopia:server:create", chdir: root, exception: true)
+		system("git", "config", "--local", "core.sharedRepository", "false", chdir: root, exception: true)
+		system("chmod", "-Rf", "g-x", ".git", chdir: root, exception: true)
+		system("rm", "-f", ".git/hooks/post-receive", chdir: root, exception: true)
+		
+		# Run the server update command:
+		system("bundle", "exec", "bake", "utopia:server:update", chdir: root, exception: true)
+		
+		# Check a couple of files to make sure they have group read and write access after the update:
+		Dir.glob(File.join(root, ".git/**/*")).each do |path|
+			expect(group_rw(path)).to be == true
 		end
 	end
 	
 	it "can generate sample site, server and push to the server" do
-		Dir.mktmpdir("test") do |dir|
-			site_path = File.join(dir, "site")
-			FileUtils.mkdir_p(site_path)
-			
-			server_path = File.join(dir, "server")
-			FileUtils.mkdir_p(server_path)
-			
-			install_packages(site_path)
-			install_packages(server_path)
-			
-			system("bundle", "exec", "bake", "utopia:site:create", chdir: site_path, exception: true)
-			branch = IO.popen(["git", "branch", "--show-current"], chdir: site_path, &:read)
-			expect(branch).to be == "main\n"
-			
-			system("bundle", "exec", "bake", "utopia:server:create", chdir: server_path, exception: true)
-			branch = IO.popen(["git", "branch", "--show-current"], chdir: server_path, &:read)
-			expect(branch).to be == "main\n"
-			
-			system("git", "push", "--set-upstream", server_path, "main", chdir: site_path, exception: true)
-			
-			expected_files = %W[.git gems.rb gems.locked readme.md bake.rb config.ru lib pages public]
-			server_files = Dir.entries(server_path)
-			
-			expected_files.each do |file|
-				expect(server_files).to be(:include?, file)
-			end
-			
-			expect(File.executable? File.join(server_path, "config.ru")).to be == true
-			puts File.stat(File.join(dir, "server", ".git")).mode
+		site_path = File.join(root, "site")
+		FileUtils.mkdir_p(site_path)
+		
+		server_path = File.join(root, "server")
+		FileUtils.mkdir_p(server_path)
+		
+		install_packages(site_path)
+		install_packages(server_path)
+		
+		system("bundle", "exec", "bake", "utopia:site:create", chdir: site_path, exception: true)
+		branch = IO.popen(["git", "branch", "--show-current"], chdir: site_path, &:read)
+		expect(branch).to be == "main\n"
+		
+		system("bundle", "exec", "bake", "utopia:server:create", chdir: server_path, exception: true)
+		branch = IO.popen(["git", "branch", "--show-current"], chdir: server_path, &:read)
+		expect(branch).to be == "main\n"
+		
+		system("git", "push", "--set-upstream", server_path, "main", chdir: site_path, exception: true)
+		
+		expected_files = %W[.git gems.rb gems.locked readme.md bake.rb config.ru lib pages public]
+		server_files = Dir.entries(server_path)
+		
+		expected_files.each do |file|
+			expect(server_files).to be(:include?, file)
 		end
+		
+		expect(File.executable? File.join(server_path, "config.ru")).to be == true
 	end
 end


### PR DESCRIPTION
## Summary
- Replace direct `Dir.mktmpdir` usage in command specs with `Sus::Fixtures::TemporaryDirectoryContext`.
- Drop the now-unused `tmpdir` require.

## Testing
- `git diff --check`
- `bundle exec rubocop --format simple`
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=init.defaultBranch GIT_CONFIG_VALUE_0=main bundle exec sus test/utopia/command.rb`