### PR TITLE
Initialize generated repositories on main

### DIFF
--- a/bake/utopia/server.rb
+++ b/bake/utopia/server.rb
@@ -31,7 +31,10 @@ SERVER_ROOT = File.join(SETUP_ROOT, "server")
 def update(root: context.root)
 	# It's okay to call this on an existing repo, it will only update config as required to enable --shared.
 	# --shared allows multiple users to access the site with the same group.
-	system("git", "init", "--shared", chdir: root) or fail "could not initialize repository"
+	arguments = ["git", "init", "--shared"]
+	arguments << "--initial-branch=main" unless File.exist?(File.join(root, ".git"))
+	
+	system(*arguments, chdir: root) or fail "could not initialize repository"
 	
 	system("git", "config", "receive.denyCurrentBranch", "ignore", chdir: root) or fail "could not set configuration"
 	system("git", "config", "core.worktree", root, chdir: root) or fail "could not set configuration"

--- a/bake/utopia/site.rb
+++ b/bake/utopia/site.rb
@@ -67,10 +67,10 @@ def create(root: context.root)
 	
 	context.lookup("utopia:environment:setup").call(root: root)
 	
-	if !File.exist?(".git")
+	if !File.exist?(File.join(root, ".git"))
 		Console.info(self){"Setting up git repository..."}
 		
-		system("git", "init", chdir: root) or warn "could not create git repository"
+		system("git", "init", "--initial-branch=main", chdir: root) or warn "could not create git repository"
 		system("git", "add", ".", chdir: root) or warn "could not add all files"
 		system("git", "commit", "-q", "-m", "Initial Utopia v#{Utopia::VERSION} site.", chdir: root) or warn "could not commit files"
 	end

--- a/test/utopia/command.rb
+++ b/test/utopia/command.rb
@@ -95,8 +95,6 @@ describe "utopia command" do
 	end
 	
 	it "can generate sample site, server and push to the server" do
-		# This assumes your default branch is "main". We should probably be more flexible around this.
-		# git config --global init.defaultBranch main
 		Dir.mktmpdir("test") do |dir|
 			site_path = File.join(dir, "site")
 			FileUtils.mkdir_p(site_path)
@@ -108,7 +106,12 @@ describe "utopia command" do
 			install_packages(server_path)
 			
 			system("bundle", "exec", "bake", "utopia:site:create", chdir: site_path, exception: true)
+			branch = IO.popen(["git", "branch", "--show-current"], chdir: site_path, &:read)
+			expect(branch).to be == "main\n"
+			
 			system("bundle", "exec", "bake", "utopia:server:create", chdir: server_path, exception: true)
+			branch = IO.popen(["git", "branch", "--show-current"], chdir: server_path, &:read)
+			expect(branch).to be == "main\n"
 			
 			system("git", "push", "--set-upstream", server_path, "main", chdir: site_path, exception: true)
 			


### PR DESCRIPTION
## Summary
- Initialize generated site repositories with `main` explicitly.
- Initialize new generated server repositories with `main` while avoiding the initial-branch option on existing server repos during update.
- Assert generated site and server branches in the command spec.

## Testing
- `git diff --check`
- `bundle exec rubocop --format simple`
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=init.defaultBranch GIT_CONFIG_VALUE_0=master bundle exec sus test/utopia/command.rb`