### PR TITLE
Reuse bundle path in command tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.context
 /.bundle
 /pkg
+/vendor
 /gems.locked
 /.covered.db
 /external

--- a/test/utopia/command.rb
+++ b/test/utopia/command.rb
@@ -27,6 +27,10 @@ describe "utopia command" do
 	
 	REQUIRED_GEMS = ["bake", "bake-test", "sus", "covered", "rack-test", "sus-fixtures-async-http", "falcon", "net-smtp", "benchmark-http", "protocol-rack"]
 	
+	def bundle_path
+		File.join(utopia_path, "vendor/bundle")
+	end
+	
 	def install_packages(dir)
 		gems_path = File.join(dir, "gems.rb")
 		File.open(gems_path, "w") do |file|
@@ -37,7 +41,7 @@ describe "utopia command" do
 			end
 		end
 		
-		system("bundle", "config", "set", "path", "vendor/bundle", chdir: dir)
+		system("bundle", "config", "set", "path", bundle_path, chdir: dir)
 		system("bundle", "install", chdir: dir)
 	end
 	


### PR DESCRIPTION
The generated command specs currently configure each temporary app with its own local `vendor/bundle`, which means every generated app performs a fresh nested bundle install.

This changes those generated apps to use the Utopia checkout's `vendor/bundle`, matching the path configured by `ruby/setup-ruby` / `ruby/setup-ruby-pkgs` with Bundler caching enabled. Each generated app still keeps its own bundle config and lock state; only installed gem files are shared.

Local checks:

```sh
bundle exec rubocop --format simple
# 133 files inspected, no offenses detected

time bundle exec sus test/utopia/command.rb
# 4 passed out of 4 total (53 assertions)
# ~17s with cold shared install path, ~7s once warm locally
```